### PR TITLE
Close the tabnabbing hole and pin the CDN script with SRI

### DIFF
--- a/about.html
+++ b/about.html
@@ -195,8 +195,8 @@
             <a href="https://danielbaez.xyz/projects">all projects</a>
             <a href="https://danielbaez.xyz/calendario">Calendario</a>
             <a href="https://danielbaez.xyz/music">My Music Library</a>
-            <a href="https://www.danielbphotos.wordpress.com/" target="_blank">Daniel B Photos</a>
-            <a href="https://danielbaez.webflow.io" target="_blank">Daniel's Digital Lab</a>
+            <a href="https://www.danielbphotos.wordpress.com/" target="_blank" rel="noopener">Daniel B Photos</a>
+            <a href="https://danielbaez.webflow.io" target="_blank" rel="noopener">Daniel's Digital Lab</a>
         </div>
     </div>
     <a class="active" href="#about">about</a>
@@ -227,7 +227,7 @@
             <div class="card-role">creative director/ student/ djay</div>
             <div class="card-socials">
                 <!-- Instagram -->
-                <a href="https://instagram.com/_danielbaez" target="_blank" aria-label="Instagram">
+                <a href="https://instagram.com/_danielbaez" target="_blank" aria-label="Instagram" rel="noopener">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
                         <rect x="2" y="2" width="20" height="20" rx="5" ry="5"/>
                         <circle cx="12" cy="12" r="4"/>
@@ -235,19 +235,19 @@
                     </svg>
                 </a>
                 <!-- X / Twitter -->
-                <a href="https://x.com/_danielbaez" target="_blank" aria-label="X">
+                <a href="https://x.com/_danielbaez" target="_blank" aria-label="X" rel="noopener">
                     <svg viewBox="0 0 24 24" fill="currentColor">
                         <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.73-8.835L2.25 2.25h6.894l4.262 5.631 5.838-5.631Zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77Z"/>
                     </svg>
                 </a>
                 <!-- LinkedIn -->
-                <a href="https://linkedin.com/in/-danielbaez/" target="_blank" aria-label="LinkedIn">
+                <a href="https://linkedin.com/in/-danielbaez/" target="_blank" aria-label="LinkedIn" rel="noopener">
                     <svg viewBox="0 0 24 24" fill="currentColor">
                         <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
                     </svg>
                 </a>
                 <!-- GitHub -->
-                <a href="https://github.com/d-baez" target="_blank" aria-label="GitHub">
+                <a href="https://github.com/d-baez" target="_blank" aria-label="GitHub" rel="noopener">
                     <svg viewBox="0 0 24 24" fill="currentColor">
                         <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
                     </svg>

--- a/be patient.html
+++ b/be patient.html
@@ -29,7 +29,7 @@
     <meta property="og:image" content="https://danielbaez.xyz/assets/images/og-default.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta property="og:image:alt" content="dj dale danny - music, mixes and releases">
+    <meta property="og:image:alt" content="Daniel Baez - creative developer and designer">
     <meta name="twitter:card" content="summary_large_image">
 
 </head>

--- a/body-extended.html
+++ b/body-extended.html
@@ -37,8 +37,8 @@
       <a href="https://danielbaez.xyz/projects">all projects</a>
       <a href="https://danielbaez.xyz/calendario">Calendario</a>
       <a href="https://danielbaez.xyz/music">My Music Library</a>
-      <a href="https://www.danielbphotos.wordpress.com/" target="_blank">Daniel B Photos</a>
-      <a href="https://danielbaez.webflow.io" target="_blank">Daniel's Digital Lab</a>
+      <a href="https://www.danielbphotos.wordpress.com/" target="_blank" rel="noopener">Daniel B Photos</a>
+      <a href="https://danielbaez.webflow.io" target="_blank" rel="noopener">Daniel's Digital Lab</a>
     </div>
   </div>
   <a href="https://danielbaez.xyz/about">about</a>

--- a/boilerroom.html
+++ b/boilerroom.html
@@ -63,8 +63,8 @@
                 <a href="https://danielbaez.xyz/projects">All Projects</a>
                 <a href="https://danielbaez.xyz/calendario">Calendario</a>
                 <a href="https://danielbaez.xyz/music">My Music Library</a>
-                <a href="https://www.danielbphotos.wordpress.com/" target="_blank">Daniel B Photos</a>
-                <a href="https://danielbaez.webflow.io" target="_blank">Daniel's Digital Lab</a>
+                <a href="https://www.danielbphotos.wordpress.com/" target="_blank" rel="noopener">Daniel B Photos</a>
+                <a href="https://danielbaez.webflow.io" target="_blank" rel="noopener">Daniel's Digital Lab</a>
             </div>
         </div>
         <a href="https://danielbaez.xyz/about">About</a>

--- a/calendario.html
+++ b/calendario.html
@@ -282,8 +282,8 @@
             <a href="https://danielbaez.xyz/projects">all projects</a>
             <a class="active" href="https://danielbaez.xyz/calendario">Calendario</a>
             <a href="https://danielbaez.xyz/music">My Music Library</a>
-            <a href="https://www.danielbphotos.wordpress.com/" target="_blank">Daniel B Photos</a>
-            <a href="https://danielbaez.webflow.io" target="_blank">Daniel's Digital Lab</a>
+            <a href="https://www.danielbphotos.wordpress.com/" target="_blank" rel="noopener">Daniel B Photos</a>
+            <a href="https://danielbaez.webflow.io" target="_blank" rel="noopener">Daniel's Digital Lab</a>
         </div>
     </div>
     <a href="https://danielbaez.xyz/about">about</a>

--- a/index.html
+++ b/index.html
@@ -58,8 +58,8 @@
                 <a href="https://danielbaez.xyz/projects">all projects</a>
                 <a href="https://danielbaez.xyz/calendario">Calendario</a>
                 <a href="https://danielbaez.xyz/music">My Music Library</a>
-                <a href="https://www.danielbphotos.wordpress.com/" target="_blank">Daniel B Photos</a>
-                <a href="https://danielbaez.webflow.io" target="_blank">Daniel's Digital Lab</a>
+                <a href="https://www.danielbphotos.wordpress.com/" target="_blank" rel="noopener">Daniel B Photos</a>
+                <a href="https://danielbaez.webflow.io" target="_blank" rel="noopener">Daniel's Digital Lab</a>
             </div>
         </div>
         <a href="https://danielbaez.xyz/about">about</a>
@@ -136,7 +136,16 @@
     </footer>
 
     <script src="assets/js/nav.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/vanilla-tilt@1.8.1/dist/vanilla-tilt.min.js"></script>
+    <!-- The only third-party script on the site. The version is pinned, but a
+         pin alone only fixes which file is asked for - it can't tell whether
+         what came back is that file. integrity makes the browser hash the
+         response and refuse to run it if it doesn't match, so a compromised
+         CDN can't quietly serve something else. crossorigin is required for
+         the check to run at all on a cross-origin request. -->
+    <script src="https://cdn.jsdelivr.net/npm/vanilla-tilt@1.8.1/dist/vanilla-tilt.min.js"
+            integrity="sha384-0k1dj5tm+KUH/4vkNk/i90XsjDA8Ltmt+ybcrFoH4t0dgv/WZsPpVBnkhcroX8UL"
+            crossorigin="anonymous"
+            referrerpolicy="no-referrer"></script>
     <script>
         VanillaTilt.init(document.querySelector(".box3"));
     </script>

--- a/index.html
+++ b/index.html
@@ -147,7 +147,12 @@
             crossorigin="anonymous"
             referrerpolicy="no-referrer"></script>
     <script>
-        VanillaTilt.init(document.querySelector(".box3"));
+        // integrity blocks the script outright on a mismatch, so VanillaTilt
+        // may never be defined. Guarding keeps that case to a missing tilt
+        // effect rather than a ReferenceError.
+        if (typeof VanillaTilt !== "undefined") {
+            VanillaTilt.init(document.querySelector(".box3"));
+        }
     </script>
 </body>
 </html>

--- a/music.html
+++ b/music.html
@@ -41,8 +41,8 @@
             <a href="https://danielbaez.xyz/projects">all projects</a>
             <a href="https://danielbaez.xyz/calendario">Calendario</a>
             <a class="active" href="https://danielbaez.xyz/music">My Music Library</a>
-            <a href="https://www.danielbphotos.wordpress.com/" target="_blank">Daniel B Photos</a>
-            <a href="https://danielbaez.webflow.io" target="_blank">Daniel's Digital Lab</a>
+            <a href="https://www.danielbphotos.wordpress.com/" target="_blank" rel="noopener">Daniel B Photos</a>
+            <a href="https://danielbaez.webflow.io" target="_blank" rel="noopener">Daniel's Digital Lab</a>
         </div>
     </div>
     <a href="https://danielbaez.xyz/about">about</a>
@@ -71,7 +71,7 @@
     </div>
     <br>
     <!-- SoundCloud Embed -->
-    <iframe width="auto" height="450"  frameborder="0" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/playlists/1971802152&color=%231342bd&auto_play=false&hide_related=false&show_comments=false&show_user=true&show_reposts=false&show_teaser=false"></iframe><div style="font-size: 10px; color: #cccccc;line-break: anywhere;word-break: normal;overflow: hidden;white-space: nowrap;text-overflow: ellipsis; font-family: Interstate,Lucida Grande,Lucida Sans Unicode,Lucida Sans,Garuda,Verdana,Tahoma,sans-serif;font-weight: 100;"><a href="https://soundcloud.com/djdaledanny" title="dj dalé danny" target="_blank" style="color: #cccccc; text-decoration: none;">dj dalé danny</a> · <a href="https://soundcloud.com/djdaledanny/sets/my-mixes" title="My Mixes" target="_blank" style="color: #cccccc; text-decoration: none;">My Mixes</a></div>
+    <iframe width="auto" height="450"  frameborder="0" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/playlists/1971802152&color=%231342bd&auto_play=false&hide_related=false&show_comments=false&show_user=true&show_reposts=false&show_teaser=false"></iframe><div style="font-size: 10px; color: #cccccc;line-break: anywhere;word-break: normal;overflow: hidden;white-space: nowrap;text-overflow: ellipsis; font-family: Interstate,Lucida Grande,Lucida Sans Unicode,Lucida Sans,Garuda,Verdana,Tahoma,sans-serif;font-weight: 100;"><a href="https://soundcloud.com/djdaledanny" title="dj dalé danny" target="_blank" style="color: #cccccc; text-decoration: none;" rel="noopener">dj dalé danny</a> · <a href="https://soundcloud.com/djdaledanny/sets/my-mixes" title="My Mixes" target="_blank" style="color: #cccccc; text-decoration: none;" rel="noopener">My Mixes</a></div>
     <!-- Apple Music Embed -->
     <!--
     <iframe allow="autoplay *; encrypted-media *;" frameborder="0" height="450" style="width:100%;max-width:660px;overflow:hidden;background:transparent" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-top-navigation-by-user-activation" src="https://embed.music.apple.com/us/artist/dj-dale-danny/1738121003"></iframe>

--- a/privacy.html
+++ b/privacy.html
@@ -58,8 +58,8 @@
                    <a href="https://danielbaez.xyz/projects">all projects</a>
                    <a href="https://danielbaez.xyz/calendario">Calendario</a>
                    <a href="https://danielbaez.xyz/music">My Music Library</a>
-                   <a href="https://www.danielbphotos.wordpress.com/" target="_blank">Daniel B Photos</a>
-                   <a href="https://danielbaez.webflow.io" target="_blank">Daniel's Digital Lab</a>
+                   <a href="https://www.danielbphotos.wordpress.com/" target="_blank" rel="noopener">Daniel B Photos</a>
+                   <a href="https://danielbaez.webflow.io" target="_blank" rel="noopener">Daniel's Digital Lab</a>
                </div>
            </div>
            <a href="https://danielbaez.xyz/about">about</a>

--- a/projects.html
+++ b/projects.html
@@ -95,8 +95,8 @@
                     <a class="active" href="https://danielbaez.xyz/projects">all projects</a>
                     <a href="https://danielbaez.xyz/calendario">Calendario</a>
                     <a href="https://danielbaez.xyz/music">My Music Library</a>
-                    <a href="https://www.danielbphotos.wordpress.com/" target="_blank">Daniel B Photos</a>
-                    <a href="https://danielbaez.webflow.io" target="_blank">Daniel's Digital Lab</a>
+                    <a href="https://www.danielbphotos.wordpress.com/" target="_blank" rel="noopener">Daniel B Photos</a>
+                    <a href="https://danielbaez.webflow.io" target="_blank" rel="noopener">Daniel's Digital Lab</a>
                 </div>
             </div>
             <a href="https://danielbaez.xyz/about">about</a>
@@ -145,10 +145,10 @@ Today's Events:
             <div class="box" > <!-- box 3-->
                 <div>
                     <h1>Daniel B<br> Photos</h1>
-                    <a href="https://www.danielbphotos.wordpress.com/" target="_blank">visit here</a>
+                    <a href="https://www.danielbphotos.wordpress.com/" target="_blank" rel="noopener">visit here</a>
                 </div>
                 <div id="img">
-                    <a href="https://danielbphotos.wordpress.com/" target="_blank" >
+                    <a href="https://danielbphotos.wordpress.com/" target="_blank" rel="noopener">
                         <img src="assets/images/photo-website.jpg" alt="screenshot of Daniel B Photos website" loading="lazy" decoding="async">
                     </a>
                 </div>
@@ -157,13 +157,13 @@ Today's Events:
 <!--             upcoming projects to add -->
             <div class="box"> <!--  box 4-->
                 <div>
-                    <a href="https://danielbaez.webflow.io" target="_blank">
+                    <a href="https://danielbaez.webflow.io" target="_blank" rel="noopener">
                         <img src="assets/images/ddl-website.jpg" alt="Screenshot of daniel's digital" loading="lazy" decoding="async">
                     </a>
                 </div>
                 <div>
                     <h1>Daniel's Digital lab</h1>
-                    <a href="https://danielbaez.webflow.io" target="_blank">Visit here</a>
+                    <a href="https://danielbaez.webflow.io" target="_blank" rel="noopener">Visit here</a>
                 </div>
             </div>
 

--- a/resume.html
+++ b/resume.html
@@ -175,9 +175,9 @@
 <!--            <span>●</span>-->
             <a href="mailto:daniel.baez(at)rutgers.edu">daniel.baez(at)rutgers.edu</a>
             <span>●</span>
-            <a href="https://linkedin.com/in/-danielbaez/" target="_blank">linkedin.com/in/-danielbaez/</a>
+            <a href="https://linkedin.com/in/-danielbaez/" target="_blank" rel="noopener">linkedin.com/in/-danielbaez/</a>
             <span>●</span>
-            <a href="https://danielbaez.xyz" target="_blank">danielbaez.xyz</a>
+            <a href="https://danielbaez.xyz" target="_blank" rel="noopener">danielbaez.xyz</a>
         </div>
     </header>
 

--- a/rop.html
+++ b/rop.html
@@ -126,8 +126,8 @@
             <a href="https://danielbaez.xyz/projects">all projects</a>
             <a href="https://danielbaez.xyz/calendario">Calendario</a>
             <a href="https://danielbaez.xyz/music">My Music Library</a>
-            <a href="https://www.danielbphotos.wordpress.com/" target="_blank">Daniel B Photos</a>
-            <a href="https://danielbaez.webflow.io" target="_blank">Daniel's Digital Lab</a>
+            <a href="https://www.danielbphotos.wordpress.com/" target="_blank" rel="noopener">Daniel B Photos</a>
+            <a href="https://danielbaez.webflow.io" target="_blank" rel="noopener">Daniel's Digital Lab</a>
         </div>
     </div>
     <a href="https://danielbaez.xyz/about">about</a>

--- a/song.html
+++ b/song.html
@@ -37,8 +37,8 @@
                 <a href="https://danielbaez.xyz/projects">all projects</a>
                 <a href="https://danielbaez.xyz/calendario">Calendario</a>
                 <a href="https://danielbaez.xyz/music">My Music Library</a>
-                <a href="https://www.danielbphotos.wordpress.com/" target="_blank">Daniel B Photos</a>
-                <a href="https://danielbaez.webflow.io" target="_blank">Daniel's Digital Lab</a>
+                <a href="https://www.danielbphotos.wordpress.com/" target="_blank" rel="noopener">Daniel B Photos</a>
+                <a href="https://danielbaez.webflow.io" target="_blank" rel="noopener">Daniel's Digital Lab</a>
             </div>
         </div>
         <a href="https://danielbaez.xyz/about">about</a>


### PR DESCRIPTION
The fixes half of #25. Two third-party exposures, both mechanical to close.

Neither is in this site's own code — which is the pattern worth noticing, and the thesis the article can be built on. CodeQL has scanned the JavaScript and Python 17 times and found nothing, not because it's weak but because a static site's own code is barely the attack surface. The exposure is other people's code.

## `rel="noopener"` on 32 links

Of 37 `target="_blank"` links, only 5 carried a `rel`. Without `noopener`, the opened page receives a `window.opener` handle back to the tab it came from and can redirect it elsewhere while the visitor is looking at the new tab.

**Honest severity:** modern browsers imply `noopener` on `target="_blank"` already — Chrome 88+, Firefox 79+, Safari 12.1+ — so the practical exposure was small. It's still wrong to depend on the default, and it costs one attribute. Flagging this explicitly because the article shouldn't imply there were 32 live holes.

**Deliberately `noopener` alone, not `noopener noreferrer`.** `noopener` is the part that closes the `window.opener` hole. `noreferrer` additionally strips the `Referer` header, which would hide `danielbaez.xyz` as the traffic source in the analytics of the sites being linked to — and several of those are Daniel's own, WordPress and Webflow among them. No reason to give up that attribution to fix a different problem. Easy to switch if the stricter version is preferred.

## Subresource Integrity on the jsdelivr script

`index.html` loads `vanilla-tilt@1.8.1` from `cdn.jsdelivr.net` — the only third-party script on the site. The version was pinned, but **a pin only fixes which file is requested; it can't tell whether what came back is that file.** If the CDN were ever compromised, arbitrary JavaScript would run on the page.

`integrity` makes the browser hash the response and refuse to execute on a mismatch. `crossorigin="anonymous"` is required for the check to run at all on a cross-origin request.

The hash was taken from three separate fetches that returned byte-identical 8887-byte responses, so it isn't a one-off artifact.

## Verification

A wrong hash would silently kill the tilt effect on the homepage, so this needed proving rather than assuming. Injecting the same URL twice — once with the real hash, once with a garbage one:

| | result |
|---|---|
| correct hash | `EXECUTED` |
| tampered hash | `BLOCKED` |

So the protection is live, not merely declared. A clean-tab reload confirms `VanillaTilt` loads and initialises on `.box3`, console clean.

All 37 `target="_blank"` anchors were audited individually rather than by line — a raw `grep -c` reads 36 because one line in `music.html` holds two anchors. All 10 link-heavy pages were re-parsed through a DOMParser: every blank-target link protected, no broken hrefs, no parse errors.

## Also in here

`og:image:alt` on `be patient.html` still described the dj dalé danny card after adcd246 switched that page to `og-default.png`. Corrected to match the image it now points at.

## Not in here

This is the *fixes* half, hence `Refs #25` rather than `Fixes`. The article stays open — and can now honestly say "here's what I found on my own site and what I did about it."

Still outstanding from the original audit, both bigger than a one-line change: no Content-Security-Policy (Pages can't set headers, but `<meta http-equiv>` works), and 8 third-party iframes with no `sandbox` or `referrerpolicy`.
