### PR TITLE
Add the GitHub profile as a fifth project card

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -167,6 +167,37 @@ Today's Events:
                 </div>
             </div>
 
+<!--         The profile is a portal rather than a project, so it sits last
+             alongside the other external destinations. Box 4 leads with its
+             image, so this one leads with text to keep the alternation. -->
+            <div class="box"> <!-- box 5-->
+                <div>
+                    <h1>GitHub</h1>
+                    <a href="https://github.com/d-baez" target="_blank" rel="noopener">browse the repos</a>
+                </div>
+                <div class="mock-cell">
+                    <a class="mock-link" href="https://github.com/d-baez" target="_blank" rel="noopener">
+                        <!-- A mock rather than a screenshot on purpose: a picture of
+                             GitHub's own UI would go stale every time they redesign.
+
+                             Deliberately not dressed up as `gh repo list` output -
+                             that command sorts by last update, which would surface
+                             the profile-readme repo and a course repo rather than
+                             these. This is a hand-picked five, so it says so. The
+                             names, languages and the count are real. -->
+                        <div class="card-mock"><span class="prompt">github.com/d-baez</span>
+
+d-baez.github.io          <span class="event">HTML</span>
+capstone                  <span class="event">Python</span>
+Sound-board               <span class="event">Swift</span>
+Ricoh-Resource-Monitor    <span class="event">Python</span>
+facialrec                 <span class="event">Python</span>
+
+<span class="typed">13 public repositories</span></div>
+                    </a>
+                </div>
+            </div>
+
 
         </div>
 


### PR DESCRIPTION
Adds the GitHub profile as a fifth card on the projects page.

## Placement

The profile is a portal rather than a project, so it sits last alongside the other external destinations — Daniel B Photos and the Digital Lab. Box 4 leads with its image, so this row leads with text and keeps the alternation running down the page.

## Why a mock and not a screenshot

It reuses the `.card-mock` pattern built for Calendario. A screenshot here would be a picture of GitHub's own UI, which redesigns without warning and would quietly go stale; the mock costs nothing to keep current and stays visually consistent with the other card that has no screenshot.

## The honesty call worth reviewing

The first version of this card was dressed up as `gh repo list d-baez --limit 5` output. Then I ran the command. It sorts by last update, so the real first five are:

```
d-baez.github.io
capstone
d-baez                        <- the profile-readme repo
communicate-using-markdown    <- a GitHub Skills course repo
Sound-board
```

Printing a different, nicer five underneath that command would have been a small lie on the one page whose entire job is to represent the work honestly. So the card is labelled as what it actually is — the profile URL, a hand-picked five, and the true total. Names, languages and the count of 13 are all real, and there's a comment in the markup recording why it isn't styled as command output.

## Verification

| viewport | result |
|---|---|
| 1600 | five rows share one centre (800) and one column axis (517 / 1083) |
| 398 | stacked, no page overflow |

The new mock measures identically to the Calendario one — 284px wide, no inner scroll — so the two cards sit at matching visual weight.

Also checked with the mono font forced to a fallback. A wider fallback is the plausible way a `width: max-content` card breaks out of its column, and `max-width: 100%` holds it in either case. Worth mentioning because an intermediate headless render *appeared* to show mobile overflow; that turned out to be a rendering artifact, and the numbers above are from a live server in a real viewport.

## Scope

`projects.html` only, as the issue title specifies. Adding GitHub to the nav dropdown would touch all 17 pages and is a separate decision.

## Merge note

PR #28 also touches `projects.html` — it adds `rel="noopener"` to the nav dropdown links. Whichever of the two merges second may need a trivial rebase. The new links in this PR already carry `rel="noopener"`, so the two are consistent either way.

Fixes #24
