### PR TITLE
Turn the artist statement into a live terminal

### DIFF
--- a/assets/css/styleguide.css
+++ b/assets/css/styleguide.css
@@ -210,6 +210,302 @@
 .code-punct { color: #d4d4d4; }
 .code-prompt { color: #569cd6; font-weight: bold; }
 
+/* ── Live terminal (front-page artist statement) ─────────────
+   Built on top of .code-window: same chrome, same colours. What is
+   added here is the scrolling body, the prompt line, and the retro
+   theme. See assets/js/terminal.js for the behaviour. */
+
+.terminal {
+    position: relative;
+}
+
+/* The prompt line and the key row are display:flex, and an author
+   display beats the browser's [hidden] { display: none }. Without this
+   they would both be on screen before the typing has even started. */
+.terminal [hidden] {
+    display: none;
+}
+
+.terminal:focus-within {
+    box-shadow: 0 0 0 2px rgba(39, 201, 63, 0.35), 0 4px 6px rgba(0, 0, 0, 0.15);
+}
+
+/* Deliberately not .code-window-body: that sets white-space: pre-wrap,
+   which would turn the indentation of the markup inside this container
+   into visible blank lines. The <pre> and each output line set it
+   themselves instead. */
+.terminal-body {
+    padding: 18px 20px;
+    color: #d4d4d4;
+    font-size: 0.95em;
+    line-height: 1.6;
+    /* A ceiling here means output grows into its own scroll area rather
+       than pushing the rest of the page down as commands are run. */
+    max-height: 60vh;
+    min-height: 15rem;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    cursor: text;
+}
+
+.terminal-statement {
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.terminal-skip {
+    margin-left: auto;
+    font-family: inherit;
+    font-size: 0.78em;
+    color: #8a8a8a;
+    background: transparent;
+    border: 1px solid #3a3a3a;
+    border-radius: 999px;
+    padding: 2px 10px;
+    cursor: pointer;
+}
+
+.terminal-skip:hover,
+.terminal-skip:focus-visible {
+    color: #d4d4d4;
+    border-color: #5a5a5a;
+}
+
+/* The caret that leads the auto-typing. It holds still while text is
+   being written and blinks once the line has stopped moving. */
+.term-cursor {
+    display: inline-block;
+    width: 0.55em;
+    height: 1.05em;
+    vertical-align: text-bottom;
+    background-color: #27c93f;
+    animation: term-blink 1.1s steps(1, end) infinite;
+}
+
+.terminal.is-typing .term-cursor {
+    animation: none;
+}
+
+@keyframes term-blink {
+    50% { opacity: 0; }
+}
+
+/* ── output lines ──────────────────────────────────────────── */
+
+.term-line,
+.term-echo {
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.term-space {
+    height: 0.9em;
+}
+
+.term-note { color: #9cdcfe; }
+.term-dim { color: #8a8a8a; }
+.term-warn { color: #ce9178; }
+.term-accent { color: #27c93f; }
+
+.term-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0 12px;
+}
+
+.term-key {
+    flex: 0 0 9.5rem;
+    color: #c586c0;
+}
+
+.term-val {
+    flex: 1 1 12rem;
+    min-width: 0;
+}
+
+.term-link {
+    color: #4ec9b0;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+
+.term-link:hover,
+.term-link:focus-visible {
+    color: #9cdcfe;
+}
+
+/* `ls` in a real terminal lays its columns out to fit the width it has.
+   A grid does the same thing, and reflows to one column on a phone. */
+.term-ls {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
+    gap: 2px 16px;
+    margin: 0.2em 0 0.6em;
+}
+
+.term-art {
+    margin: 0.2em 0 0.6em;
+    color: #27c93f;
+    font-size: 0.9em;
+    line-height: 1.15;
+    overflow-x: auto;
+}
+
+/* ── the prompt line ───────────────────────────────────────── */
+
+.terminal-prompt-line {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    margin-top: 4px;
+}
+
+.term-prompt {
+    flex: none;
+    color: #569cd6;
+    font-weight: bold;
+    white-space: nowrap;
+    cursor: text;
+}
+
+.term-prompt .term-cwd { margin-left: 0.5ch; color: #4ec9b0; }
+.term-prompt .term-sigil { margin-left: 0.5ch; color: #569cd6; }
+
+.term-echo .term-prompt { margin-right: 8px; }
+
+.terminal-input {
+    flex: 1 1 auto;
+    min-width: 0;
+    padding: 0;
+    background: transparent;
+    border: 0;
+    outline: none;
+    color: #d4d4d4;
+    font: inherit;
+    caret-color: #27c93f;
+}
+
+/* ── tappable commands ─────────────────────────────────────── */
+
+.terminal-keys {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    padding: 0 20px 16px;
+    border-top: 1px solid #2d2d2d;
+    padding-top: 14px;
+}
+
+.terminal-keys-label {
+    color: #8a8a8a;
+    font-size: 0.8em;
+}
+
+.terminal-keys button {
+    font-family: inherit;
+    font-size: 0.8em;
+    color: #9cdcfe;
+    background-color: #252526;
+    border: 1px solid #3a3a3a;
+    border-radius: 999px;
+    padding: 7px 13px;
+    cursor: pointer;
+}
+
+.terminal-keys button:hover,
+.terminal-keys button:focus-visible {
+    background-color: #333;
+    border-color: #5a5a5a;
+}
+
+/* ── retro: green on black ─────────────────────────────────── */
+
+.terminal.is-retro { background-color: #04170a; }
+.terminal.is-retro .code-window-header { background-color: #06230e; border-bottom-color: #0d4a1c; }
+.terminal.is-retro .code-window-title { color: #2fbf5e; }
+.terminal.is-retro .dot { background-color: #1c7a36; }
+.terminal.is-retro .terminal-body { color: #33ff77; text-shadow: 0 0 6px rgba(51, 255, 119, 0.4); }
+.terminal.is-retro .code-comment { color: #1f9c4a; }
+.terminal.is-retro .code-keyword,
+.terminal.is-retro .code-var,
+.terminal.is-retro .code-punct,
+.terminal.is-retro .term-note,
+.terminal.is-retro .term-accent,
+.terminal.is-retro .term-key,
+.terminal.is-retro .term-prompt,
+.terminal.is-retro .term-prompt .term-cwd,
+.terminal.is-retro .term-prompt .term-sigil,
+.terminal.is-retro .term-art { color: #33ff77; }
+.terminal.is-retro .code-string,
+.terminal.is-retro .term-link { color: #9dffbe; }
+.terminal.is-retro .term-dim { color: #2cc463; }
+.terminal.is-retro .term-warn { color: #d8ff5a; }
+.terminal.is-retro .term-cursor { background-color: #33ff77; }
+.terminal.is-retro .terminal-input { color: #33ff77; caret-color: #33ff77; }
+.terminal.is-retro .terminal-keys { border-top-color: #0d4a1c; }
+.terminal.is-retro .terminal-keys button { color: #33ff77; background-color: #06230e; border-color: #0d4a1c; }
+.terminal.is-retro .terminal-keys button:hover,
+.terminal.is-retro .terminal-keys button:focus-visible { background-color: #0a3213; }
+.terminal.is-retro .terminal-skip { color: #1f9c4a; border-color: #0d4a1c; }
+
+/* Scanlines. pointer-events: none so the overlay never eats a click or a
+   text selection underneath it. */
+.terminal.is-retro::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: repeating-linear-gradient(
+        to bottom,
+        rgba(0, 0, 0, 0) 0,
+        rgba(0, 0, 0, 0) 2px,
+        rgba(0, 0, 0, 0.16) 3px,
+        rgba(0, 0, 0, 0.16) 4px
+    );
+    border-radius: 10px;
+}
+
+/* Read by screen readers, never shown: the finished statement, handed
+   over up front so nobody has to sit through the typing. */
+.term-sr {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+@media (max-width: 640px) {
+    .terminal-body {
+        padding: 14px;
+        font-size: 0.8em;
+        max-height: 58vh;
+        min-height: 12rem;
+    }
+
+    /* The full host name eats most of a phone's width, so the prompt
+       shortens to the part that matters. */
+    .term-prompt .term-host { display: none; }
+    .term-prompt .term-cwd { margin-left: 0; }
+
+    .term-key { flex-basis: 100%; }
+    .term-val { flex-basis: 100%; }
+
+    .term-ls { grid-template-columns: 1fr 1fr; }
+
+    .terminal-keys { padding: 12px 14px 14px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .term-cursor { animation: none; }
+}
+
 /* Name-logo specific paragraph */
 .name-logo p {
     /*font-family: 'trap-Bold', ui-serif; !* Bold font for emphasis *!*/

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -1,0 +1,541 @@
+/*
+ * The artist statement on the front page, as a live terminal.
+ *
+ * The statement itself is plain HTML in index.html - this file finds it,
+ * empties it, and re-types it character by character once the visitor
+ * scrolls the box into view. That ordering matters: with JS off, or if this
+ * file never loads, the statement is just sitting there already rendered.
+ * Nothing here is required to read it.
+ *
+ * After the typing finishes the box drops to a real prompt that accepts a
+ * handful of commands. Everything the visitor types is written back with
+ * textContent, never innerHTML, so an echoed command is text and only text.
+ */
+(function () {
+    'use strict';
+
+    var root = document.getElementById('statement-terminal');
+    if (!root) return;
+
+    var statement = document.getElementById('statement-source');
+    var log = document.getElementById('terminal-log');
+    var form = document.getElementById('terminal-form');
+    var input = document.getElementById('terminal-input');
+    var keys = document.getElementById('terminal-keys');
+    var skipBtn = document.getElementById('terminal-skip');
+    var scroller = root.querySelector('.terminal-body');
+    if (!statement || !log || !form || !input || !scroller) return;
+
+    var code = statement.querySelector('code') || statement;
+    var reduceMotion = window.matchMedia
+        ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+        : false;
+    // Coarse pointers are phones and tablets. The rule for them is: never
+    // move focus into the input on our own, because focus is what summons
+    // the on-screen keyboard. Only a deliberate tap on the prompt does that.
+    var coarsePointer = window.matchMedia
+        ? window.matchMedia('(pointer: coarse)').matches
+        : false;
+
+    /* ── the places `ls` and `open` know about ─────────────── */
+    // Internal links stay relative so the terminal still works when the site
+    // is served from a local preview rather than danielbaez.xyz.
+    var PLACES = [
+        { key: 'calendario',  name: 'calendario/',      url: 'calendario', note: 'ai calendar assistant - case study' },
+        { key: 'music',       name: 'music-library/',   url: 'music',      note: 'the library, the sets, the mixes' },
+        { key: 'photos',      name: 'daniel-b-photos@', url: 'https://www.danielbphotos.wordpress.com/', note: 'photography, hosted elsewhere', external: true },
+        { key: 'digital-lab', name: 'digital-lab@',     url: 'https://danielbaez.webflow.io', note: "daniel's digital lab", external: true },
+        { key: 'github',      name: 'github@',          url: 'https://github.com/d-baez', note: 'the repos', external: true },
+        { key: 'resume',      name: 'resume.txt',       url: 'resume',     note: 'the formal version' },
+        { key: 'about',       name: 'about.md',         url: 'about',      note: 'who is daniel báez?' }
+    ];
+
+    /* ── small DOM helpers ─────────────────────────────────── */
+
+    function el(tag, cls, text) {
+        var node = document.createElement(tag);
+        if (cls) node.className = cls;
+        if (text != null) node.textContent = text;
+        return node;
+    }
+
+    function link(text, url, external) {
+        var a = el('a', 'term-link', text);
+        a.href = url;
+        if (external) {
+            a.target = '_blank';
+            a.rel = 'noopener';
+        }
+        return a;
+    }
+
+    function nearBottom() {
+        return scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight < 48;
+    }
+
+    // Follow the output down, but stop following the moment the visitor
+    // scrolls back up to re-read something.
+    function keepAtBottom(force) {
+        if (force || nearBottom()) scroller.scrollTop = scroller.scrollHeight;
+    }
+
+    function out(node) {
+        log.appendChild(node);
+        keepAtBottom();
+        return node;
+    }
+
+    function print(text, cls) {
+        return out(el('div', 'term-line' + (cls ? ' ' + cls : ''), text));
+    }
+
+    function blank() {
+        return out(el('div', 'term-space'));
+    }
+
+    // `label  value` rows, used by help / contact / ls -l style output.
+    function row(key, value) {
+        var line = el('div', 'term-row');
+        line.appendChild(el('span', 'term-key', key));
+        var val = el('span', 'term-val');
+        if (typeof value === 'string') val.textContent = value;
+        else val.appendChild(value);
+        line.appendChild(val);
+        return line;
+    }
+
+    function promptLabel() {
+        var frag = document.createDocumentFragment();
+        frag.appendChild(el('span', 'term-host', 'visitor@danielbaez.xyz'));
+        frag.appendChild(el('span', 'term-cwd', '~'));
+        frag.appendChild(el('span', 'term-sigil', '%'));
+        return frag;
+    }
+
+    /* ── typing the statement ──────────────────────────────── */
+
+    // Snapshot the statement before anything is cleared. Each child of
+    // <code> becomes one segment, so the typed copy keeps the exact same
+    // syntax colouring as the static markup without duplicating the text.
+    var segments = [];
+    Array.prototype.forEach.call(code.childNodes, function (node) {
+        var text = node.textContent;
+        if (!text) return;
+        segments.push({ text: text, cls: node.nodeType === 1 ? node.className : '' });
+    });
+
+    var cursor = el('span', 'term-cursor');
+    cursor.setAttribute('aria-hidden', 'true');
+    var skipped = false;
+    var timer = null;
+    var resumeTyping = null;
+
+    function renderAll() {
+        segments.forEach(function (seg) {
+            var node = seg.cls ? el('span', seg.cls, seg.text) : document.createTextNode(seg.text);
+            code.insertBefore(node, cursor);
+        });
+    }
+
+    function typeOut(done) {
+        var si = 0;
+        var ci = 0;
+        var node = null;
+
+        function tick() {
+            if (skipped) {
+                code.textContent = '';
+                code.appendChild(cursor);
+                renderAll();
+                return done();
+            }
+            if (si >= segments.length) return done();
+
+            if (!node) {
+                var seg = segments[si];
+                node = seg.cls ? el('span', seg.cls) : document.createTextNode('');
+                code.insertBefore(node, cursor);
+            }
+
+            var ch = segments[si].text.charAt(ci);
+            node.textContent += ch;
+            ci += 1;
+            if (ci >= segments[si].text.length) {
+                si += 1;
+                ci = 0;
+                node = null;
+            }
+            keepAtBottom();
+
+            // A pause at each line break is most of what sells the
+            // live-coding feel; the jitter on the rest keeps it off-grid.
+            var delay = ch === '\n' ? 110 : 5 + Math.random() * 12;
+            timer = setTimeout(tick, delay);
+        }
+
+        // Skipping cancels the pending tick, so it needs a way to run one
+        // more by hand - that last call is what paints the rest of the text.
+        resumeTyping = tick;
+        tick();
+    }
+
+    /* ── commands ──────────────────────────────────────────── */
+
+    // Kept out of `help` on purpose - they are there to be found.
+    var HIDDEN = ['sudo', 'crea', 'exit', 'dj'];
+
+    var HELP = [
+        ['help', "what you're reading"],
+        ['about', 'more about me'],
+        ['projects', "everything i've built"],
+        ['ls', 'list the projects like files'],
+        ['open <name>', 'open one of them'],
+        ['whoami', '...you tell me'],
+        ['contact', 'how to reach me'],
+        ['theme', 'flip between editor and retro green'],
+        ['clear', 'wipe the screen']
+    ];
+
+    var CREA_ART = [
+        '  ___ ___ ___   _   ',
+        ' / __| _ \\ __| /_\\  ',
+        '| (__|   / _| / _ \\ ',
+        ' \\___|_|_\\___/_/ \\_\\'
+    ].join('\n');
+
+    function goTo(url, external) {
+        if (external) {
+            // A submit / click is user activation, so this normally opens.
+            // If a blocker eats it anyway, leave the visitor a link instead
+            // of a dead end.
+            var win = window.open(url, '_blank', 'noopener');
+            if (!win) out(row('blocked', link(url, url, true)));
+            return;
+        }
+        setTimeout(function () { window.location.href = url; }, 650);
+    }
+
+    function findPlace(name) {
+        var wanted = name.toLowerCase();
+        for (var i = 0; i < PLACES.length; i++) {
+            var place = PLACES[i];
+            if (place.key === wanted || place.name.toLowerCase() === wanted) return place;
+            // so `open music-library` and `open music` both land
+            if (place.name.replace(/[\/@]$/, '').toLowerCase() === wanted) return place;
+        }
+        return null;
+    }
+
+    function setTheme(mode) {
+        root.classList.toggle('is-retro', mode === 'retro');
+        try {
+            window.localStorage.setItem('statement-terminal-theme', mode);
+        } catch (e) {
+            // Private mode and blocked storage both throw here. The theme
+            // still flips, it just won't survive a reload.
+        }
+    }
+
+    var COMMANDS = {
+        help: function () {
+            print('available commands:', 'term-note');
+            HELP.forEach(function (entry) { out(row(entry[0], entry[1])); });
+            blank();
+            print("not everything is on this list.", 'term-dim');
+        },
+
+        about: function () {
+            print('opening the about page…');
+            out(row('→', link('danielbaez.xyz/about', 'about')));
+            goTo('about');
+        },
+
+        projects: function () {
+            print('opening every project…');
+            out(row('→', link('danielbaez.xyz/projects', 'projects')));
+            goTo('projects');
+        },
+
+        contact: function () {
+            // There is no standalone contact page yet, so this is the
+            // contact page: the addresses themselves.
+            print('reach me:', 'term-note');
+            out(row('email', link('hello@danielbaez.xyz', 'mailto:hello@danielbaez.xyz')));
+            out(row('instagram', link('@_danielbaez', 'https://instagram.com/_danielbaez', true)));
+            out(row('linkedin', link('/in/-danielbaez', 'https://linkedin.com/in/-danielbaez/', true)));
+            out(row('github', link('@d-baez', 'https://github.com/d-baez', true)));
+            blank();
+            print('i answer. say what you are building.', 'term-dim');
+        },
+
+        whoami: function () {
+            print('visitor');
+            print('  ↳ except you found the prompt and typed into it. so: builder.', 'term-dim');
+            blank();
+            print('daniel báez — computer engineering student, creative director, dj.');
+            print('runs on curiosity, café, and the belief that you can just make things.');
+            print('crea lo que tu quieras.', 'term-accent');
+        },
+
+        ls: function () {
+            var grid = el('div', 'term-ls');
+            PLACES.forEach(function (place) {
+                var a = link(place.name, place.url, place.external);
+                a.title = place.note;
+                grid.appendChild(a);
+            });
+            out(grid);
+            print('try: open calendario', 'term-dim');
+        },
+
+        open: function (arg) {
+            if (!arg) {
+                print('open what? run `ls` to see the options.', 'term-warn');
+                return;
+            }
+            var place = findPlace(arg);
+            if (!place) {
+                print('open: no such project: ' + arg, 'term-warn');
+                return;
+            }
+            print('opening ' + place.name + ' — ' + place.note);
+            goTo(place.url, place.external);
+        },
+
+        theme: function (arg) {
+            var mode = arg === 'retro' || arg === 'green' ? 'retro'
+                : arg === 'editor' || arg === 'dark' ? 'editor'
+                : root.classList.contains('is-retro') ? 'editor' : 'retro';
+            setTheme(mode);
+            print(mode === 'retro'
+                ? 'phosphor mode. green on black, like it was in the basement.'
+                : 'back to the editor.', 'term-accent');
+        },
+
+        clear: function () {
+            log.textContent = '';
+            code.textContent = '';
+            statement.hidden = true;
+            keepAtBottom(true);
+        },
+
+        /* ── the ones that aren't in help ──────────────────── */
+
+        sudo: function () {
+            print('visitor is not in the sudoers file. this incident has been reported.', 'term-warn');
+            blank();
+            print("relax — you never needed permission for the part that matters.", 'term-dim');
+        },
+
+        crea: function () {
+            var art = el('pre', 'term-art', CREA_ART);
+            art.setAttribute('aria-label', 'ascii art reading crea');
+            out(art);
+            print('crea lo que tu quieras.', 'term-accent');
+            print('create whatever you want. you already have everything you need.', 'term-dim');
+            print('hazlo hoy.', 'term-accent');
+        },
+
+        dj: function () {
+            print('now playing: whatever moves the room.', 'term-accent');
+            out(row('→', link('the music library', 'music')));
+        },
+
+        exit: function () {
+            print('there is no exit. there is only the next thing you make.', 'term-dim');
+        }
+    };
+
+    var ALIASES = {
+        'ls -l': 'ls', 'dir': 'ls', 'cd': 'open', 'man': 'help', '?': 'help',
+        'cls': 'clear', 'who': 'whoami', 'email': 'contact', 'work': 'projects',
+        'quit': 'exit', 'logout': 'exit'
+    };
+
+    var NAMES = Object.keys(COMMANDS);
+
+    /* ── running a line ────────────────────────────────────── */
+
+    var history = [];
+    var historyIndex = 0;
+
+    function echo(raw) {
+        var line = el('div', 'term-echo');
+        var label = el('span', 'term-prompt');
+        label.appendChild(promptLabel());
+        line.appendChild(label);
+        line.appendChild(el('span', 'term-typed', raw));
+        out(line);
+    }
+
+    function run(raw) {
+        echo(raw);
+
+        var trimmed = raw.trim();
+        if (!trimmed) return;
+
+        history.push(trimmed);
+        historyIndex = history.length;
+
+        var lower = trimmed.toLowerCase();
+        if (ALIASES[lower]) lower = ALIASES[lower];
+
+        var space = lower.indexOf(' ');
+        var name = space === -1 ? lower : lower.slice(0, space);
+        var arg = space === -1 ? '' : lower.slice(space + 1).trim();
+        if (ALIASES[name]) name = ALIASES[name];
+
+        // "crea lo que tu quieras" typed out in full should hit the egg too.
+        if (name === 'crea') arg = '';
+
+        if (COMMANDS[name]) {
+            COMMANDS[name](arg);
+        } else if (findPlace(name)) {
+            COMMANDS.open(name);
+        } else {
+            print('zsh: command not found: ' + name, 'term-warn');
+            print('try `help` — or just `ls`.', 'term-dim');
+        }
+        blank();
+    }
+
+    /* ── wiring ────────────────────────────────────────────── */
+
+    form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        var raw = input.value;
+        input.value = '';
+        run(raw);
+        keepAtBottom(true);
+    });
+
+    input.addEventListener('keydown', function (e) {
+        if (e.key === 'ArrowUp') {
+            if (!history.length) return;
+            e.preventDefault();
+            historyIndex = Math.max(0, historyIndex - 1);
+            input.value = history[historyIndex];
+        } else if (e.key === 'ArrowDown') {
+            if (!history.length) return;
+            e.preventDefault();
+            historyIndex = Math.min(history.length, historyIndex + 1);
+            input.value = historyIndex === history.length ? '' : history[historyIndex];
+        } else if (e.key === 'Tab') {
+            var partial = input.value.trim().toLowerCase();
+            if (!partial || partial.indexOf(' ') !== -1) return;
+            e.preventDefault();
+            var matches = NAMES.filter(function (n) {
+                return n.indexOf(partial) === 0 && HIDDEN.indexOf(n) === -1;
+            });
+            if (matches.length === 1) input.value = matches[0];
+            else if (matches.length > 1) print(matches.join('   '), 'term-dim');
+        } else if (e.key === 'l' && (e.ctrlKey || e.metaKey)) {
+            e.preventDefault();
+            COMMANDS.clear();
+        }
+    });
+
+    // Clicking the dead space of a terminal should put you at the prompt.
+    // On touch that would raise the keyboard unasked, so there the label is
+    // the only target - and the label is a <label for>, which handles itself.
+    if (!coarsePointer) {
+        scroller.addEventListener('click', function (e) {
+            if (form.hidden) return;
+            if (e.target.closest('a, button')) return;
+            if (window.getSelection && String(window.getSelection())) return;
+            input.focus({ preventScroll: true });
+        });
+    }
+
+    if (keys) {
+        keys.addEventListener('click', function (e) {
+            var button = e.target.closest('button[data-cmd]');
+            if (!button) return;
+            run(button.getAttribute('data-cmd'));
+            keepAtBottom(true);
+            // Same rule as above: give focus back on desktop, leave the
+            // keyboard down on touch.
+            if (!coarsePointer) input.focus({ preventScroll: true });
+        });
+    }
+
+    /* ── start when the box is scrolled into view ──────────── */
+
+    function finishIntro() {
+        root.classList.remove('is-typing');
+        if (skipBtn) skipBtn.hidden = true;
+        if (cursor.parentNode) cursor.parentNode.removeChild(cursor);
+
+        blank();
+        print('statement.js loaded. this prompt is live —', 'term-note');
+        print('type `help` to see what it knows.', 'term-note');
+        blank();
+
+        form.hidden = false;
+        if (keys) keys.hidden = false;
+        keepAtBottom(true);
+        // Deliberately no focus() here. Autofocusing would yank a phone's
+        // keyboard up the second the section scrolled past.
+    }
+
+    var started = false;
+
+    function start() {
+        if (started) return;
+        started = true;
+
+        // Hand screen readers the finished statement up front - they should
+        // not have to sit through an animation, and the typed copy below is
+        // hidden from them for the same reason.
+        var srCopy = el('div', 'term-sr', code.textContent);
+        statement.parentNode.insertBefore(srCopy, statement);
+        statement.setAttribute('aria-hidden', 'true');
+
+        code.textContent = '';
+        code.appendChild(cursor);
+
+        if (reduceMotion) {
+            renderAll();
+            finishIntro();
+            return;
+        }
+
+        root.classList.add('is-typing');
+        if (skipBtn) skipBtn.hidden = false;
+        typeOut(finishIntro);
+    }
+
+    function skip() {
+        if (!started || skipped) return;
+        skipped = true;
+        if (timer) clearTimeout(timer);
+        timer = null;
+        if (resumeTyping) resumeTyping();
+    }
+
+    if (skipBtn) skipBtn.addEventListener('click', skip);
+    root.addEventListener('click', function () {
+        if (root.classList.contains('is-typing')) skip();
+    });
+
+    try {
+        if (window.localStorage.getItem('statement-terminal-theme') === 'retro') {
+            root.classList.add('is-retro');
+        }
+    } catch (e) {
+        // no stored preference available; the default editor theme stands
+    }
+
+    if ('IntersectionObserver' in window) {
+        var observer = new IntersectionObserver(function (entries) {
+            entries.forEach(function (entry) {
+                if (!entry.isIntersecting) return;
+                observer.disconnect();
+                start();
+            });
+        }, { threshold: 0, rootMargin: '0px 0px -8% 0px' });
+        observer.observe(root);
+    } else {
+        start();
+    }
+}());

--- a/index.html
+++ b/index.html
@@ -100,12 +100,20 @@
     <section id="personal-statement">
         <div class="box4">
             <h2>my statement:</h2>
-            <div class="code-window">
+            <!-- The statement is written out here in full, already rendered.
+                 terminal.js finds it, empties it, and re-types it once the
+                 box is scrolled into view, then opens a live prompt below.
+                 With JS off none of that happens and the statement is simply
+                 sitting there - the animation is the enhancement, never the
+                 way the words get on the page. -->
+            <div class="code-window terminal" id="statement-terminal">
                 <div class="code-window-header">
                     <span class="dot dot-red"></span><span class="dot dot-yellow"></span><span class="dot dot-green"></span>
                     <span class="code-window-title">statement.js</span>
+                    <button type="button" class="terminal-skip" id="terminal-skip" hidden>skip &rsaquo;&rsaquo;</button>
                 </div>
-                <pre class="code-window-body"><code><span class="code-comment">// you are allowed to take up space, be loud about who you are.</span>
+                <div class="terminal-body">
+                    <pre class="terminal-statement" id="statement-source"><code><span class="code-comment">// you are allowed to take up space, be loud about who you are.</span>
 <span class="code-comment">// we are all living this day by day — no one is ahead of you.</span>
 
 <span class="code-keyword">const</span> <span class="code-var">values</span> <span class="code-punct">=</span> <span class="code-punct">[</span>
@@ -113,6 +121,26 @@
   <span class="code-string">"share resources where you can!!"</span><span class="code-punct">,</span>
   <span class="code-string">"ayuda donde puedas"</span><span class="code-punct">,</span>
 <span class="code-punct">];</span></code></pre>
+                    <div class="terminal-log" id="terminal-log" role="log" aria-live="polite"></div>
+                    <form class="terminal-prompt-line" id="terminal-form" hidden>
+                        <label class="term-prompt" for="terminal-input"><span class="term-host">visitor@danielbaez.xyz</span><span class="term-cwd">~</span><span class="term-sigil">%</span></label>
+                        <input class="terminal-input" id="terminal-input" type="text"
+                               autocomplete="off" autocapitalize="none" autocorrect="off"
+                               spellcheck="false" enterkeyhint="go" aria-label="terminal command">
+                    </form>
+                </div>
+                <!-- Touch has no keyboard sitting there waiting, so the
+                     commands double as buttons. They are useful on a mouse
+                     too - they say out loud that the box is interactive. -->
+                <div class="terminal-keys" id="terminal-keys" hidden>
+                    <span class="terminal-keys-label">tap:</span>
+                    <button type="button" data-cmd="help">help</button>
+                    <button type="button" data-cmd="ls">ls</button>
+                    <button type="button" data-cmd="whoami">whoami</button>
+                    <button type="button" data-cmd="contact">contact</button>
+                    <button type="button" data-cmd="theme">theme</button>
+                    <button type="button" data-cmd="clear">clear</button>
+                </div>
             </div>
         </div>
     </section>
@@ -136,6 +164,7 @@
     </footer>
 
     <script src="assets/js/nav.js"></script>
+    <script src="assets/js/terminal.js" defer></script>
     <!-- The only third-party script on the site. The version is pinned, but a
          pin alone only fixes which file is asked for - it can't tell whether
          what came back is that file. integrity makes the browser hash the


### PR DESCRIPTION
The artist statement on the front page was a static code-window mock. It now types itself out and then hands over a working prompt.

## Flow

Lazy — an IntersectionObserver holds everything until the box scrolls into view. Then the statement types itself at roughly 80 chars/sec with per-character jitter and a beat at each line break, about 4.5s end to end. A `skip ››` button in the title bar (and a click anywhere in the box) jumps to the end. Once it finishes, the prompt opens.

## Commands

`help`, `about`, `projects`, `contact`, `whoami`, `ls`, `open <name>`, `theme`, `clear` — plus ↑/↓ history and tab completion. Unknown input gets a `zsh: command not found`.

A few more are deliberately kept out of `help` and out of completion.

`theme` flips to green-on-black with scanlines and remembers the choice in localStorage. `ls` lists the projects as files (`calendario/`, `github@`, `resume.txt`) in a grid that reflows the way real `ls` columns adapt to terminal width.

## Progressive enhancement

The statement stays in `index.html` as plain, already-rendered HTML. `terminal.js` finds it, reads its child nodes into segments so the typed copy keeps the exact same syntax colouring, and only empties it at the moment typing starts. Script blocked, JS off, or the observer never firing all leave the statement fully readable — the animation is the enhancement, never how the words get on the page.

Screen readers get the finished text up front in a visually-hidden copy; the animated one is `aria-hidden`. Command output goes to a separate `role="log"` region, whole lines at a time.

Every echo goes through `textContent`, so what a visitor types stays text.

## Mobile

Touch has no keyboard sitting there waiting, so the commands double as tappable buttons. Nothing calls `focus()` on its own — autofocusing would drag a phone's keyboard up the moment the section scrolled past — so the keyboard only appears if someone taps the prompt itself.

## Verified

Browser-tested at desktop and 375px widths: lazy trigger (nothing happens above the fold, typing starts on scroll-in), skip, every command, chip-to-command mapping, arrow-key history, tab completion, retro theme, and a real tap confirming focus lands on the button rather than the input.

## Two things to flag

1. **There is no contact page.** `contact` prints the addresses instead of linking anywhere — email from `privacy.html`, socials from `about.html`. If a real contact page gets built, it's a two-line change.
2. **`about` and `projects` navigate away** after ~700ms rather than just printing a link. That's a reading of "links to the about page"; easy to switch to inline-link-only if that's wrong.

Still open from the original request: live testing on an actual phone. 375px emulated is not a real thumb on a real keyboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)